### PR TITLE
Fixed  ‘myField isn‘t defined’ if editor not null.

### DIFF
--- a/assets/editor.js
+++ b/assets/editor.js
@@ -54,7 +54,7 @@ $(function () {
             var cursorPos = startPos;
             editor.value = editor.value.substring(0, startPos)
                 + tag
-                + editor.value.substring(endPos, myField.value.length);
+                + editor.value.substring(endPos, editor.textLength);
             cursorPos += tag.length;
             editor.focus();
             editor.selectionStart = cursorPos;


### PR DESCRIPTION
修复编辑器中内容不为空的情况下，插入视频出现错误“editor.js:57 Uncaught ReferenceError: myField is not defined”